### PR TITLE
Add mexbin dir automatically to MATLAB path.

### DIFF
--- a/src/MATFrost.jl
+++ b/src/MATFrost.jl
@@ -3,7 +3,7 @@ using Scratch
 
 mexdir() = @get_scratch!("mexbin") 
 
-matlabpath() = joinpath(pkgdir(MATFrost), "src", "matlab") * ";" * mexdir()
+matlabpath() = joinpath(pkgdir(MATFrost), "src", "matlab")
 
 matlabpathexamples() = matlabpath() * ";" * joinpath(pkgdir(MATFrost), "examples", "01-MATFrostHelloWorld")
 

--- a/src/matlab/private/getmatfrostjuliacall.m
+++ b/src/matlab/private/getmatfrostjuliacall.m
@@ -4,7 +4,10 @@ function mjlname = getmatfrostjuliacall(juliaexe)
     mjlname = matfrostjuliacallname(juliaexe);
     if ~exist(mjlname, "file")
         mexdir = matfrostmexdir(juliaexe);
-        matfrostmake(juliaexe, mexdir, mjlname);
+        addpath(mexdir);
+        if ~exist(mjlname, "file")
+            matfrostmake(juliaexe, mexdir, mjlname);
+        end
     end
 
 end


### PR DESCRIPTION
Simplify setup by configuring the mexbin dir automatically on MATLAB path.

closes #30 