### PR TITLE
Prevent unnecessary array copies and improve the memory model

### DIFF
--- a/src/matfrostjuliacall/converttojulia.hpp
+++ b/src/matfrostjuliacall/converttojulia.hpp
@@ -262,7 +262,8 @@ public:
         } else if(marr.getNumberOfElements() != 1) {
             throw not_scalar_value_exception(marr.getDimensions(), jltype, matlabPtr);
         } else {
-            return jlbox(((matlab::data::TypedArray<T>&&) std::move(marr))[0]);
+            const matlab::data::TypedArray<T> mtarr(marr);
+            return jlbox(mtarr[0]);
         }
     }
 };
@@ -287,7 +288,8 @@ public:
         } else if(marr.getNumberOfElements() != 1) {
             throw not_scalar_value_exception(marr.getDimensions(), jltype, matlabPtr);
         } else {
-            std::complex<T> v = ((matlab::data::TypedArray<std::complex<T>>&&) std::move(marr))[0];
+            const matlab::data::TypedArray<std::complex<T>> mtarr(marr);
+            std::complex<T> v = mtarr[0];
             return jl_new_struct(jltype, jlbox(v.real()), jlbox(v.imag())); 
         }
     }
@@ -801,7 +803,7 @@ std::unique_ptr<Converter> converter(jl_datatype_t* jltype){
         } else if (jltype == jl_float64_type){
             return std::unique_ptr<Converter>(new PrimitiveConverter<double>(jltype, jl_box_float64, matlab::data::ArrayType::DOUBLE));    
         } else if (jltype == jl_bool_type){
-            return std::unique_ptr<Converter>(new PrimitiveConverter<int8_t>(jltype, jl_box_bool, matlab::data::ArrayType::LOGICAL));
+            return std::unique_ptr<Converter>(new PrimitiveConverter<bool>(jltype, [](bool b){return jl_box_bool((int8_t) b);}, matlab::data::ArrayType::LOGICAL));
         } else if (jltype == jl_uint8_type){
             return std::unique_ptr<Converter>(new PrimitiveConverter<uint8_t>(jltype, jl_box_uint8, matlab::data::ArrayType::UINT8));
         } else if (jltype == jl_int8_type){

--- a/src/matfrostjuliacall/converttojulia.hpp
+++ b/src/matfrostjuliacall/converttojulia.hpp
@@ -20,7 +20,8 @@ namespace ConvertToJulia {
  */ 
 class Converter {
 public:
-    virtual jl_value_t* convert(matlab::data::Array &&marr, matlab::engine::MATLABEngine* matlabPtr);
+    virtual jl_value_t* convert(matlab::data::Array &&marr, matlab::engine::MATLABEngine* matlabPtr) = 0;
+    virtual ~Converter() = default;
 };
 
 /**

--- a/src/matfrostjuliacall/converttojulia.hpp
+++ b/src/matfrostjuliacall/converttojulia.hpp
@@ -379,7 +379,7 @@ public:
     }
 };
 
-inline jl_value_t* convert_string(matlab::data::MATLABString &&ms){
+inline jl_value_t* convert_string(matlab::data::MATLABString ms){
     if (ms.has_value()){         
         matlab::data::String sv = *ms;
         
@@ -407,8 +407,8 @@ public:
         } else if (marr.getNumberOfElements() != 1) {
             throw not_scalar_value_exception(marr.getDimensions(), jl_string_type, matlabPtr);
         } else {
-            matlab::data::StringArray &&msarr = (matlab::data::StringArray&&) std::move(marr); 
-            return convert_string((matlab::data::MATLABString&&) std::move(msarr[0]));
+            const matlab::data::StringArray msarr(marr);
+            return convert_string(msarr[0]);
         }
     }
 };
@@ -428,17 +428,17 @@ public:
         if (marr.isEmpty()){
             return (jl_value_t*) new_empty_array(marr.getDimensions(), jltype, matlabPtr);
         } else if(marr.getType() == matlab::data::ArrayType::MATLAB_STRING){
-            matlab::data::StringArray &&msarr = (matlab::data::StringArray&&) std::move(marr);
+            const matlab::data::StringArray msarr(marr);
             size_t nel = msarr.getNumberOfElements();     
     
             jl_array_t* jlarr  = new_array(msarr.getDimensions(), jltype, matlabPtr);
             
-            matlab::data::TypedIterator<matlab::data::MATLABString>&& it(std::move(msarr).begin()); 
+            matlab::data::TypedIterator<const matlab::data::MATLABString> it(msarr.begin());
 
             jl_function_t *setindex = jl_get_function(jl_base_module, "setindex!");
 
             for (size_t i = 0; i < nel; i++){
-                jl_value_t* jls = convert_string((matlab::data::MATLABString&&) std::move(it[i]));
+                jl_value_t* jls = convert_string(it[i]);
                 jl_call3(setindex, (jl_value_t*) jlarr, jls, jl_box_int64(i+1));
             }
             return (jl_value_t*) jlarr;

--- a/src/matfrostjuliacall/converttomatlab.hpp
+++ b/src/matfrostjuliacall/converttomatlab.hpp
@@ -19,7 +19,8 @@ namespace ConvertToMATLAB {
  */ 
 class Converter {
 public:
-    virtual matlab::data::Array convert(jl_value_t* jlval, matlab::engine::MATLABEngine* matlabPtr);
+    virtual matlab::data::Array convert(jl_value_t* jlval, matlab::engine::MATLABEngine* matlabPtr) = 0;
+    virtual ~Converter() = default;
 };
 
 /**

--- a/src/matfrostjuliacall/matfrostjuliacall.cpp
+++ b/src/matfrostjuliacall/matfrostjuliacall.cpp
@@ -221,7 +221,7 @@ public:
             jlargs[0] = (jl_value_t*) jfs.function;
 
             for (size_t i=0; i < nargs; i++){
-                jlargs[i+1] = MATFrost::ConvertToJulia::convert(std::move(inputs[i+1]), jfs.arguments[i], i, matlabPtr);
+                jlargs[i+1] = MATFrost::ConvertToJulia::convert(inputs[i+1], jfs.arguments[i], i, matlabPtr);
             }
 
             jl_value_t **jlargs_p = jlargs;


### PR DESCRIPTION
If an array is marked as `const` as in `const matlab::data::TypedArray<double>`, array access will not lead to copying of data. 
Additionally, the memory model has been made more robust by sending arrays as value instead of reference.