### PR TITLE
Fix MATFrost test incompatibillities on Linux due to Union type output.

### DIFF
--- a/test/MATFrostTest/src/MATFrostTest.jl
+++ b/test/MATFrostTest/src/MATFrostTest.jl
@@ -6,8 +6,15 @@ elementwise_addition_f64(c::Float64, x::Vector{Float64}) = c .+ x
 
 kron_product_matrix_f64(A::Matrix{Float64}, B::Matrix{Float64}) = kron(A, B)
 
-sum_vector_of_vector_f64(vs::Vector{Vector{Float64}}) = sum(sum(v) for v in vs)
-
+function sum_vector_of_vector_f64(vs::Vector{Vector{Float64}}) :: Float64 
+    acc = 0.0
+    for v in vs
+        for e in v
+           acc += e 
+        end
+    end
+    acc
+end
 
 struct SimplePopulationType
     name::String
@@ -16,7 +23,15 @@ end
 
 largest_population(p1::SimplePopulationType, p2::SimplePopulationType) = ifelse(p1.population > p2.population, p1, p2)
 
-largest_population_vector(ps::Vector{SimplePopulationType}) = last(sort(ps, lt=(p1, p2)-> p1.population < p2.population))
+function largest_population_vector(ps::Vector{SimplePopulationType})
+    mp = ps[1]
+    for p in ps
+        if mp.population < p.population
+            mp = p
+        end
+    end
+    mp
+end
 
 
 struct Nest1
@@ -26,7 +41,7 @@ struct Nest1
     v4::Bool
 end
 
-sum_nest1(v::Nest1) = v.v1 + v.v2 + v.v3[1]+v.v3[2]+v.v3[3]
+sum_nest1(v::Nest1) :: Float64 = v.v1 + v.v2 + v.v3[1]+v.v3[2]+v.v3[3]
 
 nest1_identity(v::Nest1) = v
 
@@ -35,7 +50,7 @@ struct Nest2
     vs::Vector{Nest1}
 end
 
-sum_nest2(v::Nest2) = sum(sum_nest1(e) for e in v.v1) + sum(sum_nest1(e) for e in v.vs)
+sum_nest2(v::Nest2) :: Float64 = sum(sum_nest1(e) for e in v.v1) + sum(sum_nest1(e) for e in v.vs; init=0.0)
 
 nest2_identity(v::Nest2) = v
 
@@ -292,7 +307,10 @@ for (suf, prim) in (
     eval(:($(string_arr3_s)(v::Array{$(prim), 3}) = string(v)))
 
 
-    eval(:($(Symbol(:nested_structures_test1_, suf))(v::Nest3_L1{$(prim)}) = nested_structures_test1(v)))
+    eval(:($(Symbol(:nested_structures_test1_scalar_, suf))(v::Nest3_L1{$(prim)}) = nested_structures_test1(v)))
+
+    
+    eval(:($(Symbol(:nested_structures_test1_vector_, suf))(v::Nest3_L1{Vector{$(prim)}}) = nested_structures_test1(v)))
 end
 
 

--- a/test/matfrost_nested_structures_test.m
+++ b/test/matfrost_nested_structures_test.m
@@ -89,7 +89,57 @@ classdef matfrost_nested_structures_test < matfrost_abstract_test
             nest4_o.v5 = nest3_l1.v7;
 
             tc.verifyEqual(...
-                tc.mjl.MATFrostTest.("nested_structures_test1_" + jltype)(nest3_l1), ...
+                tc.mjl.MATFrostTest.("nested_structures_test1_scalar_" + jltype)(nest3_l1), ...
+                nest4_o);
+
+        end
+
+
+        function nested_structures_test1_vectors(tc, jltype, val)
+
+            if iscell(val)
+                val = repmat({val}, 5,1);
+            else
+                val = repmat(val, 5,1);
+            end
+
+            nest3_l3.v1 = val;
+            nest3_l3.v2 = 3.0;
+            nest3_l3.v3 = int64(23);
+
+
+            nest3_l2.v1 = val;
+%             if iscell(val)
+                nest3_l2.v2 = repmat({val}, 10,1);
+%             else
+%                 nest3_l2.v2 = repmat(val, 10,1);
+%             end
+            nest3_l2.v3 = repmat(nest3_l3, 10,1);
+
+            nest3_l1.v1 = int64(23);
+            nest3_l1.v2 = 323.0;
+            nest3_l1.v3 = val;
+            nest3_l1.v4 = repmat({val}, 3,1);
+%             if iscell(val)
+                nest3_l1.v5 = repmat({val}, 5,1);
+                nest3_l1.v6 = repmat({val}, 5,5);
+%             else
+%                 nest3_l1.v5 = repmat(val, 5,1);
+%                 nest3_l1.v6 = repmat(val, 5,5);
+%             end
+%              
+            nest3_l1.v7 = nest3_l2;
+            nest3_l1.v8 = repmat(nest3_l2, 10,1);
+
+
+            nest4_o.v1 = nest3_l1.v2;
+            nest4_o.v2 = nest3_l1.v1;
+            nest4_o.v3 = repmat(nest3_l1, 2,2,2);
+            nest4_o.v4 = nest3_l1.v3;
+            nest4_o.v5 = nest3_l1.v7;
+
+            tc.verifyEqual(...
+                tc.mjl.MATFrostTest.("nested_structures_test1_vector_" + jltype)(nest3_l1), ...
                 nest4_o);
 
         end


### PR DESCRIPTION
Makes tests compatible on Linux, see #38 