### PR TITLE
Add CI/CD pipelines

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,4 +1,4 @@
-name: TagBot
+name: Julia TagBot
 on:
   issue_comment:
     types:

--- a/.github/workflows/run-tests-dispatch.yml
+++ b/.github/workflows/run-tests-dispatch.yml
@@ -1,0 +1,44 @@
+name: "Dispatch tests with inputs"
+
+on:
+  workflow_dispatch:
+    inputs:
+    os:
+      required: true
+      description: "Operating system"
+      default: "windows-latest"
+      type: choice
+      options:
+        - 'windows-latest'
+        - 'ubuntu-20.04'
+        - 'macos-latest'
+    matlab-version:
+      required: true
+      description: "MATLAB version"
+      type: choice
+      options:
+        - 'R2021a'
+        - 'R2021b'
+        - 'R2022a'
+        - 'R2022b'
+        - 'R2023a'
+        - 'R2023b'
+        - 'R2024a'
+    julia-version:
+      required: true
+      description: "Julia version"
+      type: choice
+      options:
+        - '1.7'
+        - '1.8'
+        - '1.9'
+        - '1.10'
+
+jobs:
+  test:
+    uses: ./.github/workflows/run-tests-reusable.yml
+    secrets: inherit
+    with:
+      os: ${{ inputs.os }}
+      matlab-version: ${{ inputs.matlab-version }}
+      julia-version: ${{ inputs.julia-version }}

--- a/.github/workflows/run-tests-reusable.yml
+++ b/.github/workflows/run-tests-reusable.yml
@@ -1,0 +1,66 @@
+name: "Reusable workflow for running tests" 
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        description: "Operating system"
+        default: "windows-latest"
+        type: string
+      matlab-version:
+        required: true
+        description: "MATLAB version"
+        default: "R2022b"
+        type: string
+      julia-version:
+        required: true
+        description: "Julia version"
+        default: "1.10"
+        type: string
+
+jobs:
+  test:
+    runs-on: ${{ inputs.os }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: julia-actions/install-juliaup@v2
+        with:
+          channel: ${{ inputs.julia-version }}
+
+      - name: Set up MATLAB on Unix/Mac
+        uses: matlab-actions/setup-matlab@v2
+        if: !contains(${{ inputs.os }}, 'windows')
+        with:
+          release: ${{ inputs.matlab-version }}
+          cache: true
+
+      - name: Set up MATLAB on Windows
+        uses: matlab-actions/setup-matlab@v2
+        if: startsWith(${{ inputs.os }}, 'windows')
+        with:
+          release: ${{ inputs.matlab-version }}
+          cache: true
+          products: >
+            ${{ contains(inputs.matlab-version, '2024') && 'MATLAB_Support_for_MinGW-w64_C/C++/Fortran_Compiler' || 'MATLAB_Support_for_MinGW-w64_C/C++_Compiler' }}
+        
+      - name: Run tests
+        uses: matlab-actions/run-tests@v2
+        env:
+          JULIA_VERSION: ${{ inputs.julia-version }}
+        with:
+          source-folder: 'src/matlab'
+          select-by-folder: 'test'
+          strict: false
+          test-results-junit: test-reults/results.xml
+          code-coverage-cobertura: test-reults/coverage.xml
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with: 
+          path: test-reults
+          name: results-${{ inputs.matlab-version }}-${{ inputs.julia-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,12 +1,42 @@
-name: Run Tests
+name: Run Tests Automation
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
+      - '.github/workflows/run-tests.yml'
+      - '.github/workflows/run-tests-reusable.yml'
+  pull_request:
+    branches:
+      - main
+    types: 
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
+      - '.github/workflows/run-tests.yml'
+      - '.github/workflows/run-tests-reusable.yml'
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    uses: ./.github/workflows/run-tests-reusable.yml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-latest', 'ubuntu-20.04', 'macos-latest']
+        matlab-version: ['R2021b', 'R2022b', 'R2023b']
+        julia-version: ['1.7', '1.8', '1.9', '1.10']
+    with:
+      os: ${{ matrix.os }}
+      matlab-version: ${{ matrix.matlab-version }}
+      julia-version: ${{ inpmatrixuts.julia-version }}


### PR DESCRIPTION
This PR adds 3 workflows: 
- a workflow_call workflow to run all tests for a given os, MATLAB and Julia version. 
- a workflow_dispatch workflow to run for a single environment
- a workflow call that is triggered to run for all environments after a push/pr to main. 