### PR TITLE
Change order of validation to 1. array shape 2. datatype compatability.

### DIFF
--- a/test/matfrost_exception_incompatible_array_dimensions_test.m
+++ b/test/matfrost_exception_incompatible_array_dimensions_test.m
@@ -1,24 +1,23 @@
 classdef matfrost_exception_incompatible_array_dimensions_test < matfrost_abstract_test
-    
-    
-    properties (TestParameter)
-        prim_type = {
-                "bool"; 
-                "string";
-                "simple_population_type";
-                "named_tuple_simple_population_type";
-                "tup_f64_i64_bool_string";
-                "i8"; "ui8"; "i16"; "ui16"; "i32"; "ui32"; "i64"; "ui64"; ...
-                "f32"; "f64"; ...
-                "ci8"; "cui8"; "ci16"; "cui16"; "ci32"; "cui32"; "ci64"; "cui64"; ...
-                "cf32"; "cf64"};
 
-        v = {...
+
+    properties (TestParameter)
+        jltype = {
+            "bool"; 
+            "string";
+            "tup_f64_i64_bool_string";  
+            "i8"; "ui8"; "i16"; "ui16"; "i32"; "ui32"; "i64"; "ui64"; ...
+            "f32"; "f64"; ...
+            "ci8"; "cui8"; "ci16"; "cui16"; "ci32"; "cui32"; "ci64"; "cui64"; ...
+            "cf32"; "cf64";
+            
+            "simple_population_type";
+            "named_tuple_simple_population_type"};
+
+        val = {...
                 true;
                 "test";
-                struct("name", "Test", "population", int64(200));
-                struct("name", "Test", "population", int64(200));
-                {3.0; int64(3); true; "Test"};
+                 {3.0; int64(3); true; "Test"};
                 ...
                 int8(8);          uint8(14);
                 int16(478);       uint16(4532);
@@ -32,88 +31,55 @@ classdef matfrost_exception_incompatible_array_dimensions_test < matfrost_abstra
                 complex(int16(478), int16(124));
                 complex(uint16(4532), uint16(544));
                 complex(int32(323442), int32(74571));
-                complex(uint32(53342), uint32(56123));... 
+                complex(uint32(53342), uint32(56123));
                 complex(int64(323434542), int64(84968213));
-                complex(uint64(535345342), uint64(8492313));...
+                complex(uint64(535345342), uint64(8492313));
                 ...
                 complex(single(34.125), single(4234.5));  
-                complex(2342.0625, 12444.0625)}; 
-
-
+                complex(2342.0625, 12444.0625);
+                ...
+                struct("name", "Test", "population", int64(200))}; 
         
     end
-
-
-    
-    methods(Test, ParameterCombination="sequential")
-
-        function identity_vector_sanity(tc, prim_type, v)
-            if iscell(v)
-                vs = {v;v;v;v;v};
+   
+   
+    methods(Test, ParameterCombination="exhaustive")
+       
+        function row_vector_error(tc, val, jltype)
+            if iscell(val)
+                vs = repmat({val}, 1, 5);
             else
-                vs = [v;v;v;v;v];
+                vs = repmat(val, 1, 5);
             end
-            tc.verifyEqual(tc.mjl.MATFrostTest.("identity_vector_" + prim_type)(vs), vs);
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + jltype)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
         end
 
-        function identity_matrix_sanity(tc, prim_type, v)
-            if iscell(v)
-                vs = repmat({v}, 5, 5);
+        function matrix_value_to_vector_type_error(tc, val, jltype)
+            if iscell(val)
+                vs = repmat({val}, 5, 5);
             else
-                vs = repmat(v, 5, 5);
+                vs = repmat(val, 5, 5);
             end
-            tc.verifyEqual(tc.mjl.MATFrostTest.("identity_matrix_" + prim_type)(vs), vs);
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + jltype)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
         end
 
-        function identity_arr3_sanity(tc, prim_type, v)
-            if iscell(v)
-                vs = repmat({v}, 5, 5, 5);
+        function arr3_value_to_matrix_type_error(tc, val, jltype)
+            if iscell(val)
+                vs = repmat({val}, 5, 5, 5);
             else
-                vs = repmat(v, 5, 5, 5);
+                vs = repmat(val, 5, 5, 5);
             end
-            tc.verifyEqual(tc.mjl.MATFrostTest.("identity_arr3_" + prim_type)(vs), vs);
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_matrix_" + jltype)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
         end
 
-        function row_vector_error(tc, prim_type, v)
-            if iscell(v)
-                vs = repmat({v}, 1, 5);
+        function arr4_value_to_arr3_type_error(tc, val, jltype)
+            if iscell(val)
+                vs = repmat({val}, 5, 5, 5, 5);
             else
-                vs = repmat(v, 1, 5);
+                vs = repmat(val, 5, 5, 5, 5);
             end
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + prim_type)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_arr3_" + jltype)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
         end
-
-        function matrix_value_to_vector_type_error(tc, prim_type, v)
-            if iscell(v)
-                vs = repmat({v}, 5, 5);
-            else
-                vs = repmat(v, 5, 5);
-            end
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + prim_type)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
-        end
-
-        function arr3_value_to_matrix_type_error(tc, prim_type, v)
-            if iscell(v)
-                vs = repmat({v}, 5, 5, 5);
-            else
-                vs = repmat(v, 5, 5, 5);
-            end
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_matrix_" + prim_type)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
-        end
-
-        function arr4_value_to_arr3_type_error(tc, prim_type, v)
-            if iscell(v)
-                vs = repmat({v}, 5, 5, 5, 5);
-            else
-                vs = repmat(v, 5, 5, 5, 5);
-            end
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_arr3_" + prim_type)(vs), 'matfrostjulia:conversion:incompatibleArrayDimensions');
-        end
-
-
-
-
 
     end
-    
 end

--- a/test/matfrost_exception_incompatible_datatypes_test.m
+++ b/test/matfrost_exception_incompatible_datatypes_test.m
@@ -11,7 +11,7 @@ classdef matfrost_exception_incompatible_datatypes_test < matfrost_abstract_test
         jltypes = {
             "bool"; 
             "string";
-            "tup_f64_i64_bool_string";
+            "tup_f64_i64_bool_string";  % 
             "i8"; "ui8"; "i16"; "ui16"; "i32"; "ui32"; "i64"; "ui64"; ...
             "f32"; "f64"; ...
             "ci8"; "cui8"; "ci16"; "cui16"; "ci32"; "cui32"; "ci64"; "cui64"; ...
@@ -23,7 +23,7 @@ classdef matfrost_exception_incompatible_datatypes_test < matfrost_abstract_test
         vs = {...
                 true;
                 "test";
-                {3.0; int64(3); true; "Test"};
+                 {3}; % {3.0; int64(3); true; "Test"};
                 ...
                 int8(8);          uint8(14);
                 int16(478);       uint16(4532);
@@ -91,21 +91,21 @@ classdef matfrost_exception_incompatible_datatypes_test < matfrost_abstract_test
         function scalar_val_scalar_jltype_incompatible_datatypes(tc, val, jltype)
             tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + jltype)(val), 'matfrostjulia:conversion:incompatibleDatatypes');
         end
-        
-        function vector_val_scalar_jltype_incompatible_datatypes(tc, val, jltype)
-            if iscell(val)
-                vals = repmat({val}, 5, 1);
-            else
-                vals = repmat(val, 5, 1);
-            end
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + jltype)(vals), 'matfrostjulia:conversion:incompatibleDatatypes');
-        end
+%         
+%         function vector_val_scalar_jltype_incompatible_datatypes(tc, val, jltype)
+%             if iscell(val)
+%                 vals = repmat({val}, 5, 1);
+%             else
+%                 vals = repmat(val, 5, 1);
+%             end
+%             tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + jltype)(vals), 'matfrostjulia:conversion:notScalarValue');
+%         end
 
 
-
-        function scalar_val_vector_jltype_incompatible_datatypes(tc, val, jltype)
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + jltype)(val), 'matfrostjulia:conversion:incompatibleDatatypes');
-        end
+% 
+%         function scalar_val_vector_jltype_incompatible_datatypes(tc, val, jltype)
+%             tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + jltype)(val), 'matfrostjulia:conversion:incompatibleArrayDimensions');
+%         end
 
         function vector_val_vector_jltype_incompatible_datatypes(tc, val, jltype)
             if iscell(val)
@@ -116,12 +116,12 @@ classdef matfrost_exception_incompatible_datatypes_test < matfrost_abstract_test
             tc.verifyError(@() tc.mjl.MATFrostTest.("identity_vector_" + jltype)(vals), 'matfrostjulia:conversion:incompatibleDatatypes');
         end
 
-
-        
-
-        function scalar_val_matrix_jltype_incompatible_datatypes(tc, val, jltype)
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_matrix_" + jltype)(val), 'matfrostjulia:conversion:incompatibleDatatypes');
-        end
+% 
+%         
+% 
+%         function scalar_val_matrix_jltype_incompatible_datatypes(tc, val, jltype)
+%             tc.verifyError(@() tc.mjl.MATFrostTest.("identity_matrix_" + jltype)(val), 'matfrostjulia:conversion:incompatibleArrayDimensions');
+%         end
 
 
         function matrix_val_matrix_jltype_incompatible_datatypes(tc, val, jltype)

--- a/test/matfrost_exception_not_scalar_value_test.m
+++ b/test/matfrost_exception_not_scalar_value_test.m
@@ -1,22 +1,29 @@
 classdef matfrost_exception_not_scalar_value_test < matfrost_abstract_test
-    
-    
-    properties (TestParameter)
-        prim_type = {"bool";
-                "string";
-                "simple_population_type";
-                "named_tuple_simple_population_type";
-                "i8"; "ui8"; "i16"; "ui16"; "i32"; "ui32"; "i64"; "ui64"; ...
-                "f32"; "f64"; ...
-                "ci8"; "cui8"; "ci16"; "cui16"; "ci32"; "cui32"; "ci64"; "cui64"; ...
-                "cf32"; "cf64"};
+% Test the behaviour of calling functions with arguments of different
+% datatypes. In this case exceptions should be thrown of incompatible
+% datatypes. A matrix is created on one side a set of values (vs) and on the
+% other side the corresponding jltypes. The pairs in this matrix which
+% should be incompatible are tested.
 
-        v = {...
-                false;
+
+
+    properties (TestParameter)
+        jltype = {
+            "bool"; 
+            "string";
+%             "tup_f64_i64_bool_string";  % 
+            "i8"; "ui8"; "i16"; "ui16"; "i32"; "ui32"; "i64"; "ui64"; ...
+            "f32"; "f64"; ...
+            "ci8"; "cui8"; "ci16"; "cui16"; "ci32"; "cui32"; "ci64"; "cui64"; ...
+            "cf32"; "cf64";
+            
+            "simple_population_type";
+            "named_tuple_simple_population_type"};
+
+        val = {...
+                true;
                 "test";
-                ...
-                struct("name", "Test", "population", int64(200));
-                struct("name", "Test", "population", int64(200));
+                 {3}; % {3.0; int64(3); true; "Test"};
                 ...
                 int8(8);          uint8(14);
                 int16(478);       uint16(4532);
@@ -30,50 +37,49 @@ classdef matfrost_exception_not_scalar_value_test < matfrost_abstract_test
                 complex(int16(478), int16(124));
                 complex(uint16(4532), uint16(544));
                 complex(int32(323442), int32(74571));
-                complex(uint32(53342), uint32(56123));... 
+                complex(uint32(53342), uint32(56123));
                 complex(int64(323434542), int64(84968213));
-                complex(uint64(535345342), uint64(8492313));...
+                complex(uint64(535345342), uint64(8492313));
                 ...
                 complex(single(34.125), single(4234.5));  
-                complex(2342.0625, 12444.0625)}; 
-
-
+                complex(2342.0625, 12444.0625);
+                ...
+                struct("name", "Test", "population", int64(200))}; 
         
     end
+   
+   
+    methods(Test, ParameterCombination="exhaustive")
 
-
-    
-    methods(Test, ParameterCombination="sequential")
-
-        function identity_sanity(tc, prim_type, v)
-            tc.verifyEqual(tc.mjl.MATFrostTest.("identity_" + prim_type)(v), v);
-        end
-
-        function error_empty_input(tc, prim_type, v)
-            if isnumeric(v)
-                if isreal(v)
-                    vempty = zeros(0,0, class(v));
+        function error_empty_input(tc, jltype, val)
+            if isnumeric(val)
+                if isreal(val)
+                    vempty = zeros(0,0, class(val));
                 else
-                    vempty = complex(zeros(0,0, class(v)));
+                    vempty = complex(zeros(0,0, class(val)));
                 end
             else
-                vempty = v([]);
+                vempty = val([]);
             end
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + prim_type)(vempty), 'matfrostjulia:conversion:notScalarValue');
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + jltype)(vempty), 'matfrostjulia:conversion:notScalarValue');
         end
 
-        function error_vector_numel_larger_than_1(tc, prim_type, v)
-            vs = [v;v];
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + prim_type)(vs), 'matfrostjulia:conversion:notScalarValue');
+        function error_vector_val(tc, val, jltype)
+            if iscell(val)
+                vals = repmat({val}, 5, 1);
+            else
+                vals = repmat(val, 5, 1);
+            end
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + jltype)(vals), 'matfrostjulia:conversion:notScalarValue');
         end
 
-        function error_matrix_numel_larger_than_1(tc, prim_type, v)
-            vs = [v, v; v, v];
-            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + prim_type)(vs), 'matfrostjulia:conversion:notScalarValue');
+        function error_matrix_val(tc, val, jltype)
+            if iscell(val)
+                vals = repmat({val}, 5, 5);
+            else
+                vals = repmat(val, 5, 5);
+            end
+            tc.verifyError(@() tc.mjl.MATFrostTest.("identity_" + jltype)(vals), 'matfrostjulia:conversion:notScalarValue');
         end
-
-
-
     end
-    
 end


### PR DESCRIPTION
In case of empty MATLAB values its datatypes cannot be consistently guaranteed nor is the behavior on MATLAB consistent accross versions. Due to this behavior the order of validation has been changed to start with 1. validation of array shape compatibility and then proceed with 2. validation of compatibility of datatype.