### PR TITLE
improve escaped quotes in getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Linux not supported at this point. Default library `libunwind.so` bundled with M
 # Quick start 🚀
 ```matlab
 % MATLAB
-system('julia -e "import Pkg ; Pkg.generate(""MATFrostHelloWorld"") ; Pkg.activate(""./MATFrostHelloWorld"") ; Pkg.add(name=""MATFrost"")" ; Pkg.instantiate()');
+system('julia -e "import Pkg ; Pkg.generate(\"MATFrostHelloWorld\") ; Pkg.activate(\"./MATFrostHelloWorld\") ; Pkg.add(name=\"MATFrost\") ; Pkg.instantiate()"');
    % Generate a MATFrost Julia project and add MATFrost.
 
 system('julia --project="./MATFrostHelloWorld" -e "import MATFrost ; MATFrost.install()"');


### PR DESCRIPTION
closes #70 by moving last `"` to after `Pkg.instantiate()` and replacing `""` as quoted `"` with `\"` to also support bash/linux