### PR TITLE
ci(security): downgrade ubuntu and pin actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,17 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Verify semantic pull request title
-        uses: amannn/action-semantic-pull-request@v6.1.1
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Get semantic version
-        uses: RonaldPhilipsen/semVersie@v2.3.4
+        uses: RonaldPhilipsen/semVersie@41233349edfb40f4e6da4251fea7684026182dc9 # v2.3.4
         id: get-version
         with:
           add-pr-label: true
           label-prefix: false
       - name: Upload release notes
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.get-version.outputs.release == 'true'
         with:
           path: ${{ steps.get-version.outputs.release-notes-file }}
@@ -65,7 +65,7 @@ jobs:
     name: Bundle MEX binaries
     steps:
       - name: Download MEX artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: mexbin-*-R2021b-1.12
           path: mexbin
@@ -79,13 +79,13 @@ jobs:
           tar -czvf matfrost-mex-${TAG}.tar.gz -C mexbin .
 
       - name: Upload mexbinaries release zipped
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: matfrost-mex-${{ needs.version.outputs.tag }}.tar.gz
           name: mexbin-release-zipped
 
       - name: Upload mexbinaries for testing
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: mexbin/*
           name: mexbin
@@ -114,19 +114,19 @@ jobs:
     name: Create the release
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Download MEX artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: mexbin-release-zipped
         
       - name: Download Release notes
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-notes
 
-      - uses: julia-actions/install-juliaup@v3
+      - uses: julia-actions/install-juliaup@05d98a2ef433ca0723a8221e38c4723ea92b0c5f # v3.1.4
         with:
           channel: '1.12'
 
@@ -157,7 +157,7 @@ jobs:
           gh release create ${TAG} --title ${TAG} --notes-file ${{ needs.version.outputs.release-notes-file }} matfrost-mex-${TAG}.tar.gz
 
       - name: Create comment on commit
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_NOTES_FILE: ${{ needs.version.outputs.release-notes-file }}
         with:

--- a/.github/workflows/run-tests-and-build-reusable.yml
+++ b/.github/workflows/run-tests-and-build-reusable.yml
@@ -41,22 +41,22 @@ jobs:
     name: ${{ inputs.os }}-${{ inputs.matlab-version }}-julia-${{ inputs.julia-version }}-recompile-${{ inputs.mex-recompile }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Juliaup
-        uses: julia-actions/install-juliaup@v3
+        uses: julia-actions/install-juliaup@05d98a2ef433ca0723a8221e38c4723ea92b0c5f # v3.1.4
         with:
           channel: ${{ inputs.julia-version }}
 
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
         with:
           cache-name: julia-cache;version=${{ inputs.julia-version }}
           include-matrix: false
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
 
       - name: Test Julia
         if: ${{ inputs.julia-tests }}
-        uses: julia-actions/julia-runtest@v1
+        uses: julia-actions/julia-runtest@6e050c8013b833b1195105ff2fce9cd802f53271 # v1.12.0
           
       - name: Determine MATLAB product
         if: startsWith(inputs.os , 'windows')
@@ -87,7 +87,7 @@ jobs:
           gcc --version
       
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v3
+        uses: matlab-actions/setup-matlab@2323adb8243827ea460b0def4c413545aaec46a9 # v3.0.2
         with:
           release: ${{ inputs.matlab-version }}
           products: ${{ steps.matlab-product.outputs.product }}
@@ -95,20 +95,20 @@ jobs:
 
       - name: Download precompiled MEX artifacts
         if: ${{ !inputs.mex-recompile }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: 
           name: mexbin
           path: src/matlab/@matfrostjulia/private
 
        
       - name: Build MATFrost MEX
-        uses: matlab-actions/run-command@v3
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264 # v3.2.1
         if: ${{ inputs.mex-recompile }}
         with:
           command: addpath(genpath("src")) ; matfrostmake() ;
         
       - name: Run tests
-        uses: matlab-actions/run-tests@v3
+        uses: matlab-actions/run-tests@83e368e0b18d9c0c7d510fd911d546e16b73bbdb # v3.2.1
         env:
           JULIA_VERSIONS: ${{ inputs.julia-version }}
         with:
@@ -120,14 +120,14 @@ jobs:
       
       - name: Upload MEX binary
         if: ${{ inputs.mex-recompile }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: 
           path: src/matlab/@matfrostjulia/private/matfrostjuliacall.mex*
           name: mexbin-${{ inputs.os }}-${{ inputs.matlab-version }}-${{ inputs.julia-version }}
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with: 
           path: test-results
           name: results-${{ inputs.os }}-${{ inputs.matlab-version }}-${{ inputs.julia-version }}-mex-recompile-${{ inputs.mex-recompile }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Get changed files
         id: changed-files-yaml
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
         with:
           files_yaml: |
             code:
@@ -88,29 +88,29 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: results
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           files: "results/**/results.xml"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           directory: results
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           use_oidc: true
           directory: results

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         matlab-version: ['R2021b', 'R2022b', 'R2023b', 'R2024b', 'R2025b']
         julia-version: ['1.7', '1.8', '1.9', '1.10', '1.11', '1.12']
-        os: ['windows-latest', 'ubuntu-latest']
+        os: ['windows-latest', 'ubuntu-24.04']
     with:
       os: ${{ matrix.os }}
       matlab-version: ${{ matrix.matlab-version }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MATFrost"
 uuid = "406cae98-a0f7-4766-b83f-8510a556e0e7"
 authors = ["Joris Belier <joris.belier@asml.com>", "Paolo Accordini <paolo.accordini@asml.com>", "Mark Hu <mark.hu@asml.com>"]
-version = "0.5.0"
+version = "0.0.0" # Version is patched automatically during release
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/matlab/@matfrostjulia/bootstrap.jl
+++ b/src/matlab/@matfrostjulia/bootstrap.jl
@@ -4,7 +4,7 @@ The bootstrap script for launching the matfrostserver.
 
 println("Starting MATFrost server")
 
-MATFROST_MATLAB_VERSION = v"0.0.0"
+MATFROST_MATLAB_VERSION = v"0.0.0" # Version is patched automatically during release
 
 try
     using MATFrost

--- a/src/matlab/@matfrostjulia/bootstrap.jl
+++ b/src/matlab/@matfrostjulia/bootstrap.jl
@@ -4,7 +4,7 @@ The bootstrap script for launching the matfrostserver.
 
 println("Starting MATFrost server")
 
-MATFROST_MATLAB_VERSION = v"0.5.0"
+MATFROST_MATLAB_VERSION = v"0.0.0"
 
 try
     using MATFrost


### PR DESCRIPTION
As `ubuntu-latest` has shifted to 26.04 Noble. which doesn't support MATLAB R2021b